### PR TITLE
refactor cmd line options, add a few more I needed, move to subprocess to shell call

### DIFF
--- a/wkhtmltopdf/main.py
+++ b/wkhtmltopdf/main.py
@@ -2,6 +2,9 @@
 import os
 import optparse
 
+from subprocess import Popen
+from subprocess import PIPE
+
 
 class WKOption(object):
     """Build an option to be used throughout"""
@@ -157,12 +160,22 @@ class WKhtmlToPdf(object):
                         self.url,
                         self.output_file
                   )
-        sys_output = int(os.system(command))
+        try:
+            p = Popen(command, shell=True,
+                        stdout=PIPE, stderr=PIPE, close_fds=True)
+            stdout, stderr = p.communicate()
+            retcode = p.returncode
 
-        # return file if successful else return error code
-        if not sys_output:
-            return True, self.output_file
-        return False, sys_output
+            if retcode == 0:
+                # call was successful
+                return
+            elif retcode < 0:
+                raise Exception("terminated by signal: ", -retcode)
+            else:
+                raise Exception(stderr)
+
+        except OSError, exc:
+            raise exc
 
 
 def wkhtmltopdf(*args, **kwargs):


### PR DESCRIPTION
I've done some refactoring and added a few more options I needed. I didn't want to repeat the copy/pate of the command line option names, so played with a method of defining them once and reusing the OPTIONS list.

Also updated the shell call to use popen and check the return code for an error on stderr. If there is one, it raises an exception with the error so that you can call/trap the exception from pure python. I hope to use this as a library in a larger tool so want to keep errors in the python scope. Fixes #1
